### PR TITLE
Download protoc automatically in the compile phase

### DIFF
--- a/protobuf-bean/pom.xml
+++ b/protobuf-bean/pom.xml
@@ -35,7 +35,15 @@
     </dependencies>
 
     <build>
-    
+
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${os-maven-plugin.version}</version>
+            </extension>
+        </extensions>
+
         <plugins>
         
             <plugin>
@@ -50,6 +58,9 @@
                   </goals>
                 </execution>
               </executions>
+              <configuration>
+                <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+              </configuration>
             </plugin>
         
         </plugins>

--- a/protobuf-find-latest/pom.xml
+++ b/protobuf-find-latest/pom.xml
@@ -35,7 +35,15 @@
     </dependencies>
 
     <build>
-    
+
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${os-maven-plugin.version}</version>
+            </extension>
+        </extensions>
+
         <plugins>
         
             <plugin>
@@ -50,6 +58,9 @@
                   </goals>
                 </execution>
               </executions>
+              <configuration>
+                <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+              </configuration>
             </plugin>
         
         </plugins>

--- a/protobuf-validation/pom.xml
+++ b/protobuf-validation/pom.xml
@@ -26,7 +26,7 @@
             <plugin>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.6.2</version>
+                <version>${os-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>

--- a/simple-protobuf/pom.xml
+++ b/simple-protobuf/pom.xml
@@ -36,6 +36,14 @@
 
     <build>
     
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${os-maven-plugin.version}</version>
+            </extension>
+        </extensions>
+
         <plugins>
         
             <plugin>
@@ -50,6 +58,9 @@
                   </goals>
                 </execution>
               </executions>
+              <configuration>
+                <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+              </configuration>
             </plugin>
         
         </plugins>


### PR DESCRIPTION
I tried to build the simple-protobuf example, but came across the following error:

```
$ ./mvnw clean install -f simple-protobuf/pom.xml

...

[ERROR] Failed to execute goal org.xolstice.maven.plugins:protobuf-maven-plugin:0.6.1:compile (default) on project apicurio-registry-examples-simple-protobuf: An error occurred while invoking protoc: Error while executing process.: Cannot run program "protoc": error=2, No such file or directory -> [Help 1]
```

Specifying the `protocArtifact` configuration seems to resolve it, just like the protobuf-validation module.