### PR TITLE
Fix tools/kafka-all/Dockerfile to work

### DIFF
--- a/tools/kafka-all/Dockerfile
+++ b/tools/kafka-all/Dockerfile
@@ -1,13 +1,15 @@
 # docker build -t="apicurio/kafka-all" --rm .
 # docker run -it -p 9092:9092 -p 9091:9091 -p 2181:2181 apicurio/kafka-all
-# docker run -it -p 8080:8080 apicurio/apicurio-registry-mem:1.3.1.Final
-FROM centos:8
+# docker run -it -p 8080:8080 quay.io/apicurio/apicurio-registry-mem:latest-snapshot
+# (Depending on your network configuration, add `--net host` option
+# to the `docker` commands if required to make services reachable)
+FROM quay.io/centos/centos:stream8
 
 RUN yum update -y && \
     yum install -y java-1.8.0-openjdk-devel && \
-    curl http://mirror.cc.columbia.edu/pub/software/apache/kafka/2.5.0/kafka_2.12-2.5.0.tgz -o /tmp/kafka.tgz && \
+    curl https://archive.apache.org/dist/kafka/2.8.1/kafka_2.12-2.8.1.tgz -o /tmp/kafka.tgz && \
     tar xfz /tmp/kafka.tgz -C /usr/local && \
-    mv /usr/local/kafka_2.12-2.5.0 /usr/local/kafka
+    mv /usr/local/kafka_2.12-2.8.1 /usr/local/kafka
 
 RUN echo "#!/bin/sh" >> /usr/local/kafka/start_kafka.sh && \
     echo "cd /usr/local/kafka" >> /usr/local/kafka/start_kafka.sh && \


### PR DESCRIPTION
I tried to set up ZK and Kafka following the comments in tools/kafka-all/Dockerfile before running examples, but I came across the following error:

```
$ cd tools/kafka-all
$ docker build -t="apicurio/kafka-all" --rm .

...

1.019 Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist                                                                      
------                                                                                                                                                                                        
Dockerfile:6                                                                                                                                                                                  
--------------------                                                                                                                                                                          
   5 |                                                                                                                                                                                        
   6 | >>> RUN yum update -y && \                                                                                                                                                             
   7 | >>>     yum install -y java-1.8.0-openjdk-devel && \            
   8 | >>>     curl http://mirror.cc.columbia.edu/pub/software/apache/kafka/2.5.0/kafka_2.12-2.5.0.tgz -o /tmp/kafka.tgz && \
   9 | >>>     tar xfz /tmp/kafka.tgz -C /usr/local && \
  10 | >>>     mv /usr/local/kafka_2.12-2.5.0 /usr/local/kafka
  11 |                                
--------------------
ERROR: failed to solve: process "/bin/sh -c yum update -y &&     yum install -y java-1.8.0-openjdk-devel &&     curl http://mirror.cc.columbia.edu/pub/software/apache/kafka/2.5.0/kafka_2.12-2.5.0.tgz -o /tmp/kafka.tgz &&     tar xfz /tmp/kafka.tgz -C /usr/local &&     mv /usr/local/kafka_2.12-2.5.0 /usr/local/kafka" did not complete successfully: exit code: 1
```

This is because the `centos:8` image has already been deprecated, so we should use other images such as `centos:stream8` instead. In addition, there seem to be other issues in that file, e.g.,

* Kafka download URL doesn't seem to work.
* Kafka's version is obsolete a bit. It should be consolidated with the one defined in pom.xml.
* Apicurio Registry's version is also obsolete. It should be consolidated with the value in run-registry.sh.
* In my environment, the `--net host` option for the `docker` commands was required to run the simple-avro example successfully.